### PR TITLE
Update macos requirement, show requirements in downloads

### DIFF
--- a/pages/api/constants.ts
+++ b/pages/api/constants.ts
@@ -1,3 +1,10 @@
+export const osRequirements = {
+  linux:
+    'Ubuntu 20.04LTS or newer, Fedora 33 or newer, Arch Linux and derivatives (such as Manjaro, Garuda, and EndeavourOS). Heroic will work on most other Linux distros, but it may require some additional setup and troubleshooting. It is also supported on SteamOS, but downloading is only available through the Discover software center.',
+  windows: 'Windows 10 and 11',
+  macos: 'macOS 12 or newer.'
+}
+
 export const faqs: { question: string; answer: string[] }[] = [
   {
     question: 'What is Heroic?',
@@ -61,9 +68,9 @@ export const faqs: { question: string; answer: string[] }[] = [
   {
     question: 'What are the supported operating systems for Heroic?',
     answer: [
-      'Linux: Ubuntu 20.04LTS or newer, Fedora 33 or newer, Arch Linux and derivatives (such as Manjaro, Garuda, and EndeavourOS). Heroic will work on most other Linux distros, but it may require some additional setup and troubleshooting. It is also supported on SteamOS, but downloading is only available through the Discover software center.',
-      'Windows: Windows 10 and 11',
-      'macOS: macOS 10.15 or newer.'
+      `Linux: ${osRequirements.linux}`,
+      `Windows: ${osRequirements.windows}`,
+      `macOS: ${osRequirements.macos}`
     ]
   },
   {

--- a/pages/downloads.tsx
+++ b/pages/downloads.tsx
@@ -4,6 +4,7 @@ import { getLatestReleases, ReleaseUrls } from './api/github'
 import styles from '../styles/Home.module.css'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
+import { osRequirements } from './api/constants'
 
 const Downloads: NextPage = () => {
   const router = useRouter()
@@ -58,6 +59,7 @@ const Downloads: NextPage = () => {
 
           <details open={isLinux}>
             <summary>Linux</summary>
+            <p>Supported OS versions: {osRequirements.linux}</p>
             <div className="grid">
               <article className={styles.downloadBoxes}>
                 <h4>Flatpak</h4>
@@ -121,6 +123,7 @@ const Downloads: NextPage = () => {
 
           <details open={isWindows}>
             <summary>Windows</summary>
+            <p>Supported OS versions: {osRequirements.windows}</p>
             <div className="grid">
               <article className={styles.downloadBoxes}>
                 <h4>Setup</h4>
@@ -197,6 +200,7 @@ const Downloads: NextPage = () => {
 
           <details open={isMac}>
             <summary>MacOS</summary>
+            <p>Supported OS versions: {osRequirements.macos}</p>
             <div className="grid">
               <article className={styles.downloadBoxes}>
                 <h4>Intel Chips</h4>

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -11,6 +11,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  margin-top: 0px;
 }
 
 .features {


### PR DESCRIPTION
This PR includes 2 things:
- Updates macOS requirement to be 12+ based on Legendary's requirements https://github.com/derrod/legendary#requirements
- Shows the OS requirements next to the OS in the downloads section so users don't miss that (currently they can only see that either in the FAQs or the github readme)

![localhost_3000_downloads](https://user-images.githubusercontent.com/188464/226146955-b9276dbe-6473-4f7f-a922-8504d3266dbc.png)
