### PR TITLE
Fix missing versions in download page

### DIFF
--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -39,9 +39,9 @@ export const getLatestReleases = async (): Promise<ReleaseUrls> => {
     const { assets: assetsStable, tag_name: tagStable } = releases.filter(
       (rel) => rel.prerelease === false
     )[0]
-    const { assets: assetsBeta, tag_name: tagBeta } = releases.filter(
-      (rel) => rel.prerelease === true
-    )[0]
+    // const { assets: assetsBeta, tag_name: tagBeta } = releases.filter(
+    //   (rel) => rel.prerelease === true
+    // )[0]
 
     const appImageStable =
       assetsStable.filter((a) => a.name.endsWith('.AppImage'))[0]
@@ -66,7 +66,7 @@ export const getLatestReleases = async (): Promise<ReleaseUrls> => {
       dmgBeta = null,
       dmgArmBeta = null
 
-    const isSameMajor = tagStable >= tagBeta.split('-')[0]
+    // const isSameMajor = tagStable >= tagBeta.split('-')[0]
 
     /*     if (!isSameMajor) {
       appImageBeta = assetsBeta.filter((a) => a.name.endsWith('.AppImage'))[0]


### PR DESCRIPTION
The github fetch was still parsing `prereleases` but looks like it returns just a subset of all the releases and in the first 30 results there are no prereleases, so the code was failing to get the assets for those.

Part of the code was commented out before, some lines were still running that we don't need.